### PR TITLE
Improved hash jump.

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,15 +13,15 @@
     <div class='row'>
         <div class='col-sm-1 col-md-2'></div>
         <div class='col'>
-            <div class='anchor' id='about'>
+            <section class='anchor' id='about'>
                 <div class='container-fluid container-section'>
                     <h4>About Me</h4>
                     {{ range where $.Site.RegularPages "Section" "about" }}
                         {{- partial "about-entry.html" . -}}
                     {{ end }}
                 </div>
-            </div>
-            <div class='anchor' id='portfolio'>
+            </section>
+            <section class='anchor' id='portfolio'>
                 <div class='container-fluid container-section'>
                     <h4>Portfolio</h4>
                     <div class='tag_filter'>
@@ -36,14 +36,14 @@
                 {{ range where $.Site.RegularPages "Section" "portfolio" }}
                     {{- partial "portfolio-entry.html" . -}}
                 {{ end }}
-            </div>
-            <div class='anchor' id='contact'>
+            </section>
+            <section class='anchor' id='contact'>
                 <div class='container-fluid container-section'>
                 {{ range where $.Site.Pages "Section" "contact" }}
                     {{- partial "contact-entry.html" . -}}
                 {{ end }}
                 </div>
-            </div>
+            </section>
             {{- partial "footer.html" . -}}
         </div>
         <div class='col-sm-1 col-md-2'></div>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -68,7 +68,7 @@ a.anchor {
 }
 
 /* This class fixes anchor positions to account for the navbar at the top of the screen. */
-div.anchor {
+section.anchor {
     /* This offsets past the nav bar plus some extra padding so the content isn't hidden by and doesn't
        abut the nav bar after a jump. */
     padding-top: 60px;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -109,8 +109,9 @@ function setup_tag_filter() {
         event.preventDefault();
     });
 
-    apply_tag_filter(tag_filter);
+    update_tag_filter_result_count(tag_filter);
 
+    // Show the tag filter
     const tag_filter_element = document.querySelector('.tag_filter');
     tag_filter_element.style.display = 'block';
 }
@@ -166,6 +167,10 @@ function apply_tag_filter(tag_filter) {
     });
 
     // Update result count
+    update_tag_filter_result_count(tag_filter);
+}
+
+function update_tag_filter_result_count(tag_filter) {
     const num_items = document.querySelector('#num_items');
     if (tag_filter.includedItems().length === 1) {
         num_items.textContent = '1 entry matches';


### PR DESCRIPTION
Changed the tag filter so it no longer tries to apply filter results upon page load. This was unnecessary since the filter always starts in a cleared state. Furthermore, applying the tag filter on page load interrupted the browser's attempt to scroll to any provided anchor (e.g. https://jerryryle.com/#contact).