### PR TITLE
Update GitHub Actions for Node.js 24 support

### DIFF
--- a/.github/workflows/reusable-build-site.yml
+++ b/.github/workflows/reusable-build-site.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
           fetch-depth: 0   # This gets all history for .GitInfo and .Lastmod
@@ -41,7 +41,7 @@ jobs:
           make all
 
       - name: Upload built site artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.site_artifact_name }}
           path: ${{ env.HUGO_BUILD_FOLDER }}

--- a/.github/workflows/reusable-deploy-site.yml
+++ b/.github/workflows/reusable-deploy-site.yml
@@ -23,18 +23,18 @@ jobs:
       CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 
       - name: Download built site artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.site_artifact_name }}
           path: ${{ env.HUGO_BUILD_FOLDER }}
 
       - name: Configure AWS credentials from publish account
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ vars.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}


### PR DESCRIPTION
## Summary
- Update all GitHub Actions to their latest major versions to resolve Node.js 20 deprecation warnings
- `actions/checkout` v4 → v6
- `actions/upload-artifact` v4 → v7
- `actions/download-artifact` v4 → v8
- `aws-actions/configure-aws-credentials` v4 → v6

## Why
Node.js 20 actions are deprecated and will be forced to run with Node.js 24 starting June 2nd, 2026. Updating to the latest major versions ensures compatibility and removes the deprecation warnings.

## Test plan
- [ ] Verify the check-pr workflow passes on this PR
- [ ] Verify a deploy works after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)