### PR TITLE
Update Bootstrap to 5.3.8 and fix scrollspy + tag filter

### DIFF
--- a/layouts/_partials/head.html
+++ b/layouts/_partials/head.html
@@ -13,8 +13,8 @@
     <title>Jerry Ryle | Portfolio</title>
 
     <!--Bootstrap-->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css"
-          integrity="sha256-oxqX0LQclbvrsJt8IymkxnISn4Np2Wy2rY9jjoQlDEg=" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+          integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
 
     <!--Icons-->
     <link rel='apple-touch-icon' sizes='180x180' href='apple-touch-icon.png'/>

--- a/layouts/_partials/portfolio-entry.html
+++ b/layouts/_partials/portfolio-entry.html
@@ -1,4 +1,4 @@
-<div class='container-portfolio collapse.show' id='item_{{- .Params.short_name -}}'>
+<div class='container-portfolio' id='item_{{- .Params.short_name -}}'>
     <a class="anchor" id='{{- .Params.short_name -}}'></a>
     <a href='#{{- .Params.short_name -}}' class='permalink' title='Permalink for this entry'></a>
     <h4>{{ .Title }}</h4>

--- a/layouts/_partials/site-scripts.html
+++ b/layouts/_partials/site-scripts.html
@@ -1,5 +1,5 @@
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"
-        integrity="sha256-y3ibfOyBqlgBd+GzwFYQEVOZdNJD06HeDXihongBXKs=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/lazysizes/5.3.2/plugins/unveilhooks/ls.unveilhooks.min.js"
         integrity="sha512-hQ7LIAYhD17CZh6bDzdQI7NThUHmZGcAbGDfCWHO/sOEPRAdlkQFg4gTsKhWWbI1PMUvjD7JjA+5x3pH23Bnyg=="

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang='en' xmlns='http://www.w3.org/1999/xhtml'>
 {{- partials.Include "head.html" . -}}
-<body>
+<body data-bs-spy="scroll" data-bs-target="#navbar-main" data-bs-root-margin="-56px 0px -25% 0px" data-bs-threshold="0.01,0.1,0.5,1" tabindex="0">
 <nav class='navbar navbar-expand-sm fixed-top navbar-dark bg-dark'>
     <div class="container-fluid">
         <button class='navbar-toggler' type='button' data-bs-toggle='collapse'

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,7 +13,7 @@
     <div class='row'>
         <div class='col-sm-1 col-md-2'></div>
         <div class='col'>
-            <div class="scrollspy-container" data-bs-spy='scroll' data-bs-target='#navbar-main' data-bs-offset="0" tabindex="0">
+            <div class="scrollspy-container">
                 <section class='anchor' id='about'>
                     <div class='container-fluid container-section'>
                         <h4>About Me</h4>

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -159,18 +159,19 @@ function apply_tag_filter(tag_filter) {
     // Update item visibility with current filter state
     tag_filter.excludedItems().forEach(function (item_id) {
         const item = document.querySelector('#' + item_id);
-        // Hide the item
-        item.classList.remove('collapse.show');
-        item.classList.add('collapse');
+        item.classList.add('d-none');
     });
     tag_filter.includedItems().forEach(function (item_id) {
         const item = document.querySelector('#' + item_id);
-        // Show the item
-        item.classList.remove('collapse');
-        item.classList.add('collapse.show');
+        item.classList.remove('d-none');
     });
 
     update_tag_filter_result_count(tag_filter);
+
+    const scrollspy = bootstrap.ScrollSpy.getInstance(document.body);
+    if (scrollspy) {
+        scrollspy.refresh();
+    }
 }
 
 function update_tag_filter_result_count(tag_filter) {


### PR DESCRIPTION
## Summary
- Update Bootstrap from 5.3.6 to 5.3.8 with fresh SRI integrity hashes
- Fix scrollspy never highlighting "Portfolio" in the navbar — the portfolio section is so tall that Bootstrap's default IntersectionObserver threshold (0.1) was never reached. Moved scrollspy from a nested div to `<body>`, added a lower threshold (0.01), and restored Bootstrap's default bottom root margin (-25%)
- Replace the `collapse.show` class name hack in the tag filter with Bootstrap's `d-none` utility for showing/hiding portfolio entries
- Refresh scrollspy after tag filter changes so highlighting stays correct when the portfolio section height changes

## Test plan
- [ ] Verify About, Portfolio, and Contact all highlight in the navbar when scrolling through each section
- [ ] Verify tag filtering still shows/hides portfolio entries correctly
- [ ] Verify scrollspy stays correct after filtering tags (section heights change)
- [ ] Verify clicking nav items scrolls to the correct section

🤖 Generated with [Claude Code](https://claude.com/claude-code)