### PR TITLE
Clean up miscellaneous project issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ $(HUGO_BUILD_FOLDER):
 .PHONY: clean
 clean: $(HUGO_BUILD_FOLDER)
 	@echo "Cleaning build folder: $(HUGO_BUILD_FOLDER)"
-	@rm -rf "$(HUGO_BUILD_FOLDER)/*"
+	@rm -rf "$(HUGO_BUILD_FOLDER)"/*
 
 # Build the site
 .PHONY: build

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -41,17 +41,5 @@ sectionPagesMenu = "main"
 # The length of text in words to show in a .Summary.
 summaryLength = 70
 
-# Enable/disable logging.
-log = false
-
-# Log File path (if set, logging enabled automatically).
-logFile = ""
-
-# Enable/disable verbose output.
-verbose = true
-
-# Enable verbose logging.
-verboseLog = true
-
 # Increase the timeout to allow for asset generation
 timeout = 60000

--- a/layouts/_partials/contact-image.html
+++ b/layouts/_partials/contact-image.html
@@ -7,7 +7,5 @@
     <img class='img rounded mb-2'
          src='{{($page.Resources.GetMatch $page.Params.contact_photo.resource).RelPermalink}}'
 {{ end }}
-{{ if isset $page.Params.contact_photo "alt" }}
-         alt='{{ $page.Params.contact_photo.alt }}'
-{{ end }}
+         alt='{{ with $page.Params.contact_photo.alt }}{{ . }}{{ else }}Contact photo{{ end }}'
          width='100' height='100'/>

--- a/layouts/_partials/footer.html
+++ b/layouts/_partials/footer.html
@@ -1,3 +1,3 @@
 <footer>
-	<p>&copy; Jerry Ryle 2017-2025. All rights reserved.</p>
+	<p>&copy; Jerry Ryle 2017-{{ now.Year }}. All rights reserved.</p>
 </footer>

--- a/layouts/_partials/head.html
+++ b/layouts/_partials/head.html
@@ -4,8 +4,8 @@
     <meta name='description' content="Jerry Ryle's resume and portfolio."/>
     <meta name='keywords' content=''/>
     <meta name='author' content='Jerry Ryle'/>
-    <meta property='og:image' content='https://jerryryle.com/media/Site_Image.png'/>
-    <meta property='og:url' content='https://jerryryle.com'/>
+    <meta property='og:image' content='{{ "media/Site_Image.png" | absURL }}'/>
+    <meta property='og:url' content='{{ .Site.BaseURL }}'/>
     <meta property='og:title' content='Jerry Ryle'/>
     <meta property='og:description' content="Jerry Ryle's resume and portfolio"/>
     <meta property='og:type' content='website'/>

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang='en' xmlns='http://www.w3.org/1999/xhtml'>
+<html lang='en'>
 {{- partials.Include "head.html" . -}}
 <body data-bs-spy="scroll" data-bs-target="#navbar-main" data-bs-root-margin="-56px 0px -25% 0px" data-bs-threshold="0.01,0.1,0.5,1" tabindex="0">
 <nav class='navbar navbar-expand-sm fixed-top navbar-dark bg-dark'>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -49,7 +49,7 @@ h2 {
 .banner .background .image {
     height: 100%;
     width: 100%;
-    opacity: 100%;
+    opacity: 1;
 
     /* These won't apply if the background image is an SVG, but will if it's an img */
     object-fit: cover;
@@ -151,36 +151,4 @@ a.no-decorate {
     color: #aaaaaa;
     background-color: #f9f9f9;
     text-decoration: none !important;
-}
-
-/* Min Small */
-@media (min-width: 576px) {
-}
-
-/* Min Medium */
-@media (min-width: 768px) {
-}
-
-/* Min Large */
-@media (min-width: 992px) {
-}
-
-/* Min Extra large */
-@media (min-width: 1200px) {
-}
-
-/* Max Extra Small */
-@media (max-width: 575px) {
-}
-
-/* Max Small */
-@media (max-width: 767px) {
-}
-
-/* Max Medium */
-@media (max-width: 991px) {
-}
-
-/* Max Large */
-@media (max-width: 1199px) {
 }


### PR DESCRIPTION
## Summary
- Remove deprecated Hugo config keys (`log`, `logFile`, `verbose`, `verboseLog`) no longer supported in modern Hugo — use `--logLevel` CLI flag instead
- Replace hardcoded Open Graph URLs in `head.html` with Hugo template functions (`absURL`, `.Site.BaseURL`) so they derive from the configured `baseURL`
- Fix glob expansion bug in Makefile `clean` target — the `*` wildcard was inside quotes and wasn't expanding
- Fix `opacity: 100%` to standard `opacity: 1`
- Remove unnecessary XHTML namespace attribute from HTML5 `<html>` tag
- Remove 8 empty media query placeholder blocks from CSS
- Use `{{ now.Year }}` in footer copyright instead of hardcoded year
- Add fallback alt text ("Contact photo") for contact image accessibility

## Test plan
- [ ] Verify `make clean` actually removes files from the build folder
- [ ] Verify `make build` completes without warnings
- [ ] Verify Open Graph meta tags render correct URLs in built output
- [ ] Verify footer shows current year
- [ ] Verify site renders correctly with no visual regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)